### PR TITLE
Restore form submission script and move styles to stylesheet

### DIFF
--- a/script.js
+++ b/script.js
@@ -1,82 +1,59 @@
-body {
-  font-family: Arial, sans-serif;
-  background: #fff;
-  margin: 0;
-  padding: 0;
-}
+const SUPABASE_URL = 'https://ekzpwrmmbcqgsxqhtzwu.supabase.co';
+const SUPABASE_KEY = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImVrenB3cm1tYmNxZ3N4cWh0end1Iiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTEyMjcwNzAsImV4cCI6MjA2NjgwMzA3MH0.Ty9g17yf8k_3wv-I8LEhSHLwe0W3kAWc_hJks-ZiEV0';
 
-.form-container {
-  max-width: 500px;
-  margin: auto;
-  padding: 20px;
-  text-align: left;
-}
+const supabaseClient = supabase.createClient(SUPABASE_URL, SUPABASE_KEY);
 
-.logo {
-  width: 120px;
-  display: block;
-  margin: 10px auto 20px;
-}
+document.getElementById('reportForm').addEventListener('submit', async (e) => {
+  e.preventDefault();
+  const form = e.target;
 
-h2 {
-  text-align: center;
-  color: #d62828;
-}
+  const machine = form.machine.value.trim();
+  const description = form.description.value.trim();
+  const powerOff = form.powerOff.value;
+  const date = form.date.value;
+  const reporter = form.reporter.value.trim();
+  const imageFile = document.getElementById('image').files[0];
 
-label {
-  display: block;
-  margin-top: 15px;
-  font-weight: bold;
-}
+  let imageUrl = null;
 
-input[type="text"],
-input[type="time"],
-input[type="date"],
-textarea,
-input[type="file"] {
-  width: 100%;
-  padding: 8px;
-  margin-top: 4px;
-  box-sizing: border-box;
-  border-radius: 4px;
-  border: 1px solid #ccc;
-}
+  if (imageFile) {
+    const fileExt = imageFile.name.split('.').pop();
+    const filePath = `reports/${Date.now()}.${fileExt}`;
 
-textarea {
-  resize: vertical;
-}
+    const { error: storageError } = await supabaseClient.storage
+      .from('report-images')
+      .upload(filePath, imageFile);
 
-.inline-inputs {
-  display: flex;
-  gap: 10px;
-}
+    if (storageError) {
+      alert('Image upload failed.');
+      return;
+    }
 
-.inline-inputs > div {
-  flex: 1;
-}
+    const { data: publicURL } = supabaseClient
+      .storage
+      .from('report-images')
+      .getPublicUrl(filePath);
 
-button {
-  margin-top: 20px;
-  width: 100%;
-  padding: 10px;
-  background-color: #d62828;
-  color: white;
-  border: none;
-  border-radius: 4px;
-  font-size: 16px;
-}
+    imageUrl = publicURL.publicUrl;
+  }
 
-button:hover {
-  background-color: #a61c1c;
-}
+  const { error } = await supabaseClient.from('reports').insert([
+    {
+      machine,
+      description,
+      power_off_time: powerOff,
+      date,
+      reporter,
+      image_url: imageUrl,
+    }
+  ]);
 
-.hidden {
-  display: none;
-}
+  if (error) {
+    alert('Error submitting report');
+    return;
+  }
 
-#successMessage {
-  margin-top: 15px;
-  text-align: center;
-  color: green;
-}
+  form.reset();
+  document.getElementById('successMessage').classList.remove('hidden');
+});
 

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,82 @@
+body {
+  font-family: Arial, sans-serif;
+  background: #fff;
+  margin: 0;
+  padding: 0;
+}
+
+.form-container {
+  max-width: 500px;
+  margin: auto;
+  padding: 20px;
+  text-align: left;
+}
+
+.logo {
+  width: 120px;
+  display: block;
+  margin: 10px auto 20px;
+}
+
+h2 {
+  text-align: center;
+  color: #d62828;
+}
+
+label {
+  display: block;
+  margin-top: 15px;
+  font-weight: bold;
+}
+
+input[type="text"],
+input[type="time"],
+input[type="date"],
+textarea,
+input[type="file"] {
+  width: 100%;
+  padding: 8px;
+  margin-top: 4px;
+  box-sizing: border-box;
+  border-radius: 4px;
+  border: 1px solid #ccc;
+}
+
+textarea {
+  resize: vertical;
+}
+
+.inline-inputs {
+  display: flex;
+  gap: 10px;
+}
+
+.inline-inputs > div {
+  flex: 1;
+}
+
+button {
+  margin-top: 20px;
+  width: 100%;
+  padding: 10px;
+  background-color: #d62828;
+  color: white;
+  border: none;
+  border-radius: 4px;
+  font-size: 16px;
+}
+
+button:hover {
+  background-color: #a61c1c;
+}
+
+.hidden {
+  display: none;
+}
+
+#successMessage {
+  margin-top: 15px;
+  text-align: center;
+  color: green;
+}
+


### PR DESCRIPTION
## Summary
- Move inline styling from misnamed `script.js` into a proper `styles.css` file.
- Restore JavaScript form submission logic using Supabase in `script.js`.

## Testing
- `node --check script.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a7830b0f048329ba32ec53ba320391